### PR TITLE
[FEAT] PublicRoute, PrivateRoute 라우트 분리시키기

### DIFF
--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -7,6 +7,8 @@ import DashboardRoute from "./routes/app/dashboard";
 import SituationRoute from "./routes/app/situation-builder";
 // import RegisterRoute from "./routes/auth/register";
 import ConversationRoute from "./routes/app/conversation";
+import PublicLayout from "@/components/layout/PublicLayout";
+import PrivateLayout from "@/components/layout/PrivateLayout";
 
 const GlobalRouteError = () => {
   return (
@@ -20,46 +22,91 @@ const GlobalRouteError = () => {
 // ! 페이지에서 발생하는 에러 --> react-route의 errorElement로 처리
 // ! 컴포넌트 내부에서 발생하는 에러 --> ErrorBoundary로 처리
 const router = createBrowserRouter([
+  // ===========================
+  // !1) Public Routes (비로그인 전용)
+  // ===========================
   {
     path: "/",
-    element: <AppLayout />,
+    element: <PublicLayout />,
     errorElement: <GlobalRouteError />,
     children: [
       {
         path: "",
-        element: <LandingRoute />,
+        element: <AppLayout />, // 공통 레이아웃 (헤더/푸터 포함)
+        children: [
+          { index: true, element: <LandingRoute /> }, // 기본 랜딩 페이지
+        ],
+      },
+      {
+        path: "/auth/register",
+
+        lazy: async () => {
+          const { RegisterRoute } = await import("./routes/auth/register");
+          return { Component: RegisterRoute };
+        },
+      },
+      {
+        path: "/auth/login",
+        errorElement: <GlobalRouteError />,
+        lazy: async () => {
+          const { LoginRoute } = await import("./routes/auth/login");
+          return { Component: LoginRoute };
+        },
       },
     ],
   },
-  {
-    path: "/auth/register",
 
-    lazy: async () => {
-      const { RegisterRoute } = await import("./routes/auth/register");
-      return { Component: RegisterRoute };
-    },
-  },
+  // ===========================
+  // !2) Private Routes (로그인 사용자)
+  // ===========================
   {
-    path: "/auth/login",
+    path: "/app",
+    element: <PrivateLayout />,
     errorElement: <GlobalRouteError />,
-    lazy: async () => {
-      const { LoginRoute } = await import("./routes/auth/login");
-      return { Component: LoginRoute };
-    },
+    children: [
+      {
+        path: "dashboard",
+        element: <DashboardRoute />,
+      },
+      {
+        path: "c/:conversationId",
+        element: <ConversationRoute />,
+      },
+      {
+        path: "situation/new",
+        element: <SituationRoute />,
+      },
+      // {
+      //   path: "/situation/new",
+      //   element: <SituationRoute />,
+      // },
+    ],
+
+    // children: [
+    //   {
+    //     path: "dashboard",
+    //     element: <DashboardLayout />,
+    //     children: [{ index: true, element: <DashboardPage /> }], // "/app/dashboard"
+    //   },
+    //   {
+    //     path: "recommand",
+    //     element: <RecommandLayout />,
+    //     children: [{ index: true, element: <RecommandMainPage /> }], // "/app/recommand"
+    //   },
+    //   {
+    //     path: "conversation",
+    //     element: <ConversationLayout />,
+    //     children: [
+    //       { index: true, element: <ConversationMainPage /> }, // "/app/conversation"
+    //       { path: ":id", element: <ConversationMainPage /> }, // "/app/conversation/:id"
+    //     ],
+    //   },
+    // ],
   },
 
-  {
-    path: "/dashboard",
-    element: <DashboardRoute />,
-  },
-  {
-    path: "/c/:conversationId",
-    element: <ConversationRoute />,
-  },
-  {
-    path: "/situation/new",
-    element: <SituationRoute />,
-  },
+  // ===========================
+  // 3) 기타
+  // ===========================
   {
     path: "*",
     element: <NotFoundRoute />,

--- a/src/components/layout/PrivateLayout.tsx
+++ b/src/components/layout/PrivateLayout.tsx
@@ -4,6 +4,8 @@ import { Navigate, Outlet } from "react-router-dom";
 // ! 인증이 필요한 페이지의 최상단 레이아웃
 const PrivateLayout = () => {
   const { isAuthenticated } = useAuth();
+
+  console.log("In PrivateLayout", isAuthenticated);
   if (isAuthenticated === false) return <Navigate to="/auth/login" replace />;
   return <Outlet />;
 };

--- a/src/components/layout/PrivateLayout.tsx
+++ b/src/components/layout/PrivateLayout.tsx
@@ -1,0 +1,11 @@
+import { useAuth } from "@/lib/auth/authContext";
+import { Navigate, Outlet } from "react-router-dom";
+
+// ! 인증이 필요한 페이지의 최상단 레이아웃
+const PrivateLayout = () => {
+  const { isAuthenticated } = useAuth();
+  if (isAuthenticated === false) return <Navigate to="/auth/login" replace />;
+  return <Outlet />;
+};
+
+export default PrivateLayout;

--- a/src/components/layout/PublicLayout.tsx
+++ b/src/components/layout/PublicLayout.tsx
@@ -1,0 +1,12 @@
+import { useAuth } from "@/lib/auth/authContext";
+import { Navigate, Outlet } from "react-router-dom";
+
+// ! 인증이 필요없는 페이지의 최상단 레이아웃
+const PublicLayout = () => {
+  const { isAuthenticated } = useAuth();
+
+  if (isAuthenticated) return <Navigate to="/dashboard" replace />;
+  return <Outlet />;
+};
+
+export default PublicLayout;

--- a/src/components/layout/PublicLayout.tsx
+++ b/src/components/layout/PublicLayout.tsx
@@ -4,8 +4,9 @@ import { Navigate, Outlet } from "react-router-dom";
 // ! 인증이 필요없는 페이지의 최상단 레이아웃
 const PublicLayout = () => {
   const { isAuthenticated } = useAuth();
+  console.log("In PublicLayout", isAuthenticated);
 
-  if (isAuthenticated) return <Navigate to="/dashboard" replace />;
+  if (isAuthenticated) return <Navigate to="/app/dashboard" replace />;
   return <Outlet />;
 };
 

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -2,11 +2,7 @@ import { Outlet } from "react-router-dom";
 
 // ! Landing 페이지 레이아웃
 const AppLayout = () => {
-  return (
-    <div>
-      <Outlet />
-    </div>
-  );
+  return <Outlet />;
 };
 
 export default AppLayout;

--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -1,6 +1,6 @@
-import React from "react";
 import { Outlet } from "react-router-dom";
 
+// ! Landing 페이지 레이아웃
 const AppLayout = () => {
   return (
     <div>

--- a/src/components/layout/auth-layout.tsx
+++ b/src/components/layout/auth-layout.tsx
@@ -19,6 +19,7 @@ const ErrorFallback = ({
   );
 };
 
+// ! 사용자 인증 페이지 레이아웃
 const AuthLayout = ({ title, children }: AuthLayoutProps) => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-orange-100">

--- a/src/lib/auth/authContext.tsx
+++ b/src/lib/auth/authContext.tsx
@@ -16,7 +16,7 @@ const AuthContext = createContext<AuthContextType>({
 });
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(true);
   const accessTokenRef = useRef<string | null>(null);
 
   const getAccessToken = () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,40 +1,22 @@
 import path from "path";
 import react from "@vitejs/plugin-react";
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 
-// export default defineConfig({
-//   plugins: [react()],
-//   resolve: {
-//     alias: {
-//       "@": path.resolve(__dirname, "./src"),
-//     },
-//   },
-//   server: {
-//     proxy: {
-//       "/api": {
-//         target: env.API_DOMAIN_URL,
-//         changeOrigin: true,
-//         secure: true,
-//         rewrite: (path) => path.replace(/^\/api/, ""),
-//       },
-//     },
-//   },
-// });
-
-export default defineConfig(({ mode }) => {
-  const viteEnv = loadEnv(mode, process.cwd(), "VITE_APP_");
-  return {
-    plugins: [react()],
-    resolve: { alias: { "@": path.resolve(__dirname, "./src") } },
-    server: {
-      proxy: {
-        "/api": {
-          target: viteEnv.API_DOMAIN_URL,
-          changeOrigin: true,
-          secure: true,
-          rewrite: (path) => path.replace(/^\/api/, ""),
-        },
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://138.2.118.15",
+        changeOrigin: true,
+        secure: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
       },
     },
-  };
+  },
 });


### PR DESCRIPTION
### ➕ 관련 이슈
#6 

### 🔎 주요 변경 사항
- Landing, auth( Login, Register ) 페이지는 사용자 인증이 안되어야 접근 가능하게 구현
- 나머지 페이지 ( Dashboard, 추천, Conversation ) 페이지는 사용자 인증이 되어야만 접근 가능하게 구현

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 새로운 경로 구조를 도입해 인증된 사용자와 일반 사용자를 명확히 구분하여, 각각에 최적화된 레이아웃과 내비게이션을 제공합니다.
  - 로그인 및 회원가입 페이지가 비동기 로딩되어 빠른 접근성과 전환 속도를 지원하며, 사용자 인증 상태에 따라 자동으로 적절한 페이지로 안내됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->